### PR TITLE
Script doesn't work if isd-history.csv missing

### DIFF
--- a/utilities/gsod_scraper.py
+++ b/utilities/gsod_scraper.py
@@ -117,7 +117,8 @@ class GSOD(object):
             except IOError as err:
                 print('Cannot find isd-history.csv on the disk...')
                 self.wx_list_flag = True
-                self._ISDwXstationSlist()
+                df_isd = self._ISDwXstationSlist()
+                return df_isd
 
     def getAvailableWxStations(self):
         '''


### PR DESCRIPTION
Running the script with a missing 'isd-history.csv' file creates the following error:
```
Traceback (most recent call last):
  File "download_latest_data.py", line 31, in <module>
    last_ten_alb = gsod.get_data(station='725180-14735', start_year=2011, end=2021)
  File "/home/jivan/Downloads/Software/forecasting-competition/utilities/gsod_scraper.py", line 321, in get_data
    big_df['ctry'] = np.repeat(df_isd.CTRY[df_isd.STATION_ID == stn_id].values, big_df.shape[0])
AttributeError: 'NoneType' object has no attribute 'CTRY'
```

This is fixed by returning the dataframe that is created by running the function to download the csv